### PR TITLE
Modified 2 space vs 4 space logic

### DIFF
--- a/plugin/matchindent.vim
+++ b/plugin/matchindent.vim
@@ -61,7 +61,12 @@ function! MatchIndent()
 		" Mix of 2 and 4 space indents, we assume a 2 space indent since 4
 		" space indents happen in 2 space indent files. It's not perfect, but
 		" hey...
-		let use_2_spaces = 1
+		" Only use 4 if theres 4 times as many lines with 4 spaces.
+		if with_2_spaces * 4 > with_4_spaces
+			let use_2_spaces = 1
+		else
+			let use_4_spaces = 1
+		endif
 		let warn_tabs = 1
 	elseif with_tabs > 0 && with_2_spaces == 0 && with_4_spaces == 0
 		" Clear case of tab indents


### PR DESCRIPTION
I made a slight change where there has to be 4 times as many 4 space lines than 2 space lines for 4 spaces to be used. This still makes it much more likely to pick 2 spaces when there is a mix but fixes an issue I was having where one 2 space line in a large file would set tab width to 2 spaces. The choice of 4x was arbitrary but has worked well for me