### PR TITLE
Allow tabstop to be defined for tab mode viewing

### DIFF
--- a/plugin/matchindent.vim
+++ b/plugin/matchindent.vim
@@ -1,7 +1,7 @@
 " A Vim plugin which attempts to set tab preferences to match the file you're
 " editing.
-" 
-" Last Change: 2012-04-27
+"
+" Last Change: 2017-03-08
 " Maintainer: http://github.com/conormcd
 " License: www.opensource.org/licenses/bsd-license.php
 
@@ -99,9 +99,9 @@ function! MatchIndent()
 	" Actually apply the rules now
 	if use_tabs > 0
 		set noexpandtab
-		set shiftwidth=4
-		set softtabstop=4
-		set tabstop=4
+		set shiftwidth=g:matchindent_tabsize
+		set softtabstop=g:matchindent_tabsize
+		set tabstop=g:matchindent_tabsize
 	endif
 	if use_2_spaces > 0
 		set expandtab

--- a/plugin/matchindent.vim
+++ b/plugin/matchindent.vim
@@ -101,9 +101,9 @@ function! MatchIndent()
 	" Actually apply the rules now
 	if use_tabs > 0
 		set noexpandtab
-		set shiftwidth=g:matchindent_tabsize
-		set softtabstop=g:matchindent_tabsize
-		set tabstop=g:matchindent_tabsize
+		let shiftwidth=g:matchindent_tabsize
+		let softtabstop=g:matchindent_tabsize
+		let tabstop=g:matchindent_tabsize
 	endif
 	if use_2_spaces > 0
 		set expandtab

--- a/plugin/matchindent.vim
+++ b/plugin/matchindent.vim
@@ -5,6 +5,8 @@
 " Maintainer: http://github.com/conormcd
 " License: www.opensource.org/licenses/bsd-license.php
 
+let g:matchindent_tabsize = 4
+
 highlight MatchIndentBadIndent ctermbg=red guibg=red
 autocmd BufNewFile,BufRead * call MatchIndent()
 function! MatchIndent()


### PR DESCRIPTION
set the g:matchindent_tabsize variable to whatever you want tabs to
be displayed as.

Signed-off-by: Cameron Diver <cameron@resin.io>